### PR TITLE
Fixes #5. Bump without args generates an error (tested).

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
         modes.push(matches[0]);
       }
     });
-    if (this.errorCount === 0 && modes === 0) {
+    if (this.errorCount === 0 && modes.length === 0) {
       grunt.log.error('Error: no modes specified.');
     }
     if (this.errorCount > 0) {

--- a/test/bump_test.js
+++ b/test/bump_test.js
@@ -61,4 +61,20 @@ exports.bump = {
       test.done();
     });
   },
+  noargs: function(test) {
+    test.expect(2);
+
+    grunt.util.spawn({
+      grunt: true,
+      args: ['bump', '--no-color'],
+    }, function(err, result) {
+      test.notStrictEqual(err, null, 'Should points an error when bump is called without args');
+      test.equal(String(result), 
+        'Running "bump" task\n>> Error: no modes specified.\n>> Valid modes are: major, minor, patch, prerelease.'+
+        '\nWarning: Use valid modes (or unambiguous mode abbreviations). Use --force to continue.'+
+        '\n\nAborted due to warnings.', 'Should tell the args that bump should be called with'
+      );
+      test.done();
+    });
+  }
 };


### PR DESCRIPTION
I couldn't reuse testbump function to get the precise needed results for testing. And I didn't want to change it regarding the other tests robustness. 
