### PR TITLE
fixes pathspec error for commit and tag on windows

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -128,12 +128,12 @@ module.exports = function(grunt) {
   // Kinda borrowed from https://github.com/geddski/grunt-release
   function commit(filepaths, message) {
     grunt.log.writeln('Committing ' + filepaths.join(', ') + ' with message: ' + message);
-    run("git commit -m '" + message + "' '" + filepaths.join("' '") + "'");
+    run('git commit -m "' + message + '" "' + filepaths.join('" "') + '"');
   }
 
   function tag(name, message) {
     grunt.log.writeln('Tagging ' + name + ' with message: ' + message);
-    run("git tag '" + name + "' -m '" + message + "'");
+    run('git tag "' + name + '" -m "' + message + '"');
   }
 
   function run(cmd) {


### PR DESCRIPTION
("child_process").Spawn on windows can't handle `'` in the command line instead it spits out the following

```
>> Error (1) error: pathspec 'version' did not match any file(s) known to git.
>> error: pathspec 'to' did not match any file(s) known to git.
>> error: pathspec '0.5.4.'' did not match any file(s) known to git.
>> error: pathspec ''package.json'' did not match any file(s) known to git.
>> error: pathspec ''bower.json'' did not match any file(s) known to git.
```

but when replaced with `"` it works. 

So I have inverted the quotes for commit an tag
